### PR TITLE
feat: auth middleware, login page, and logout button

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,7 @@
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      {children}
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { signIn } from '@/lib/auth-client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+
+const schema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get('callbackUrl') ?? '/admin/posts';
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  async function onSubmit(values: FormValues) {
+    setError(null);
+    const { error: signInError } = await signIn.email({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (signInError) {
+      setError(signInError.message ?? 'Invalid credentials');
+      return;
+    }
+
+    router.push(callbackUrl);
+    router.refresh();
+  }
+
+  return (
+    <div className="w-full max-w-sm space-y-6 p-8 border border-border rounded-lg bg-card">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin login</h1>
+        <p className="text-sm text-muted-foreground">Sign in to manage your blog</p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" placeholder="you@example.com" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="••••••••" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? 'Signing in…' : 'Sign in'}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/components/auth/logout-button.tsx
+++ b/components/auth/logout-button.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { signOut } from '@/lib/auth-client';
+import { Button } from '@/components/ui/button';
+
+export default function LogoutButton() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await signOut();
+    router.push('/login');
+    router.refresh();
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleLogout}>
+      Sign out
+    </Button>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (!pathname.startsWith('/admin')) {
+    return NextResponse.next();
+  }
+
+  try {
+    const res = await fetch(`${API_URL}/api/auth/get-session`, {
+      headers: { cookie: request.headers.get('cookie') ?? '' },
+    });
+
+    if (res.ok) {
+      const session = await res.json();
+      if (session?.user) return NextResponse.next();
+    }
+  } catch {
+    // network error — fall through to redirect
+  }
+
+  const loginUrl = new URL('/login', request.url);
+  loginUrl.searchParams.set('callbackUrl', pathname);
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};


### PR DESCRIPTION
## Summary
- `middleware.ts` — edge middleware that checks the better-auth session cookie on every `/admin/*` request; redirects unauthenticated users to `/login?callbackUrl=...`
- `app/(auth)/layout.tsx` — minimal centered layout for auth pages (no header/sidebars)
- `app/(auth)/login/page.tsx` — email + password login form; calls `signIn.email()` from better-auth client; shows inline error on failure
- `components/auth/logout-button.tsx` — calls `signOut()` then redirects to `/login`

## Test
1. Visit `/admin/posts` while logged out → should redirect to `/login`
2. Log in with valid credentials → should redirect back to `/admin/posts`
3. Click logout → should redirect to `/login`