### PR TITLE
feat: public blog listing and post detail pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,86 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { getPost } from '@/lib/api';
+import TagBadge from '@/components/blog/tag-badge';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  try {
+    const post = await getPost(slug);
+    return {
+      title: `${post.title} — Rafi`,
+      description: post.excerpt ?? undefined,
+      openGraph: {
+        title: post.title,
+        description: post.excerpt ?? undefined,
+        images: post.coverImage ? [post.coverImage] : [],
+      },
+    };
+  } catch {
+    return { title: 'Post not found' };
+  }
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function BlogPostPage({ params }: Props) {
+  const { slug } = await params;
+
+  let post;
+  try {
+    post = await getPost(slug);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <article className="min-h-screen py-24 max-w-3xl mx-auto">
+      {/* Tags */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {post.tags.map((tag) => (
+          <TagBadge key={tag.id} tag={tag} />
+        ))}
+      </div>
+
+      {/* Title */}
+      <h1 className="text-3xl md:text-4xl font-semibold text-foreground leading-tight mb-3">
+        {post.title}
+      </h1>
+
+      {/* Date */}
+      <p className="text-sm text-muted-foreground font-mono mb-8">
+        {formatDate(post.createdAt)}
+      </p>
+
+      {/* Cover image */}
+      {post.coverImage && (
+        <div className="relative aspect-video w-full overflow-hidden rounded-lg mb-10">
+          <Image
+            src={post.coverImage}
+            alt={post.title}
+            fill
+            className="object-cover"
+            priority
+          />
+        </div>
+      )}
+
+      {/* Content — TipTap outputs HTML */}
+      <div
+        className="prose prose-slate dark:prose-invert max-w-none"
+        dangerouslySetInnerHTML={{ __html: post.content }}
+      />
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from 'next';
+import { getPosts } from '@/lib/api';
+import PostCard from '@/components/blog/post-card';
+import Pagination from '@/components/blog/pagination';
+
+export const metadata: Metadata = {
+  title: 'Blog — Abdullah Al Mohaymen Rafi',
+  description: 'Thoughts on frontend engineering, React, TypeScript, and building products.',
+};
+
+interface Props {
+  searchParams: Promise<{ page?: string }>;
+}
+
+export default async function BlogPage({ searchParams }: Props) {
+  const { page: pageParam } = await searchParams;
+  const page = Math.max(1, parseInt(pageParam ?? '1', 10));
+
+  const { data: posts, totalPages } = await getPosts(page, 6);
+
+  return (
+    <section className="min-h-screen py-24 max-w-5xl mx-auto">
+      <div className="mb-12">
+        <p className="font-mono text-primary text-sm mb-2">04. Blog</p>
+        <h1 className="text-4xl font-semibold text-foreground">Writing</h1>
+        <p className="mt-3 text-muted-foreground max-w-lg">
+          Thoughts on frontend engineering, React, TypeScript, and building products.
+        </p>
+      </div>
+
+      {posts.length === 0 ? (
+        <p className="text-muted-foreground text-center py-24">No posts published yet. Check back soon.</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {posts.map((post) => (
+              <PostCard key={post.id} post={post} />
+            ))}
+          </div>
+          <Pagination page={page} totalPages={totalPages} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/components/blog/pagination.tsx
+++ b/components/blog/pagination.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  basePath?: string;
+}
+
+export default function Pagination({ page, totalPages, basePath = '/blog' }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const btnBase = cn(buttonVariants({ variant: 'outline', size: 'sm' }));
+  const btnDisabled = cn(btnBase, 'pointer-events-none opacity-50');
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-12">
+      {page > 1 ? (
+        <Link href={`${basePath}?page=${page - 1}`} className={btnBase}>
+          ← Prev
+        </Link>
+      ) : (
+        <span className={btnDisabled}>← Prev</span>
+      )}
+
+      <span className="text-sm text-muted-foreground font-mono px-3">
+        {page} / {totalPages}
+      </span>
+
+      {page < totalPages ? (
+        <Link href={`${basePath}?page=${page + 1}`} className={btnBase}>
+          Next →
+        </Link>
+      ) : (
+        <span className={btnDisabled}>Next →</span>
+      )}
+    </div>
+  );
+}

--- a/components/blog/post-card.tsx
+++ b/components/blog/post-card.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import type { Post } from '@/lib/types';
+import TagBadge from './tag-badge';
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function PostCard({ post }: { post: Post }) {
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group flex flex-col border border-border rounded-lg overflow-hidden hover:border-primary/50 transition-colors bg-card"
+    >
+      {post.coverImage && (
+        <div className="relative aspect-video w-full overflow-hidden">
+          <Image
+            src={post.coverImage}
+            alt={post.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        </div>
+      )}
+
+      <div className="flex flex-col flex-1 gap-3 p-5">
+        <div className="flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <TagBadge key={tag.id} tag={tag} />
+          ))}
+        </div>
+
+        <h2 className="text-lg font-semibold leading-snug group-hover:text-primary transition-colors line-clamp-2">
+          {post.title}
+        </h2>
+
+        {post.excerpt && (
+          <p className="text-sm text-muted-foreground line-clamp-3 flex-1">
+            {post.excerpt}
+          </p>
+        )}
+
+        <p className="text-xs text-muted-foreground font-mono mt-auto">
+          {formatDate(post.createdAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/components/blog/tag-badge.tsx
+++ b/components/blog/tag-badge.tsx
@@ -1,0 +1,10 @@
+import { Badge } from '@/components/ui/badge';
+import type { Tag } from '@/lib/types';
+
+export default function TagBadge({ tag }: { tag: Tag }) {
+  return (
+    <Badge variant="secondary" className="text-xs font-mono">
+      {tag.name}
+    </Badge>
+  );
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -11,6 +11,7 @@ const navLinks = [
   { label: "About", href: "#about" },
   { label: "Experience", href: "#experience" },
   { label: "Projects", href: "#projects" },
+  { label: "Blog", href: "/blog" },
   { label: "Contact", href: "#contact" },
 ];
 
@@ -41,16 +42,20 @@ export default function Header() {
 
       {/* Desktop nav */}
       <nav className="hidden md:flex items-center gap-8">
-        {navLinks.map(({ label, href }, i) => (
-          <a
-            key={label}
-            href={href}
-            className="font-mono text-sm text-slate hover:text-teal transition-colors"
-          >
-            <span className="text-teal mr-1">0{i + 1}.</span>
-            {label}
-          </a>
-        ))}
+        {navLinks.map(({ label, href }, i) => {
+          const isExternal = href.startsWith('#');
+          const Tag = isExternal ? 'a' : Link;
+          return (
+            <Tag
+              key={label}
+              href={href}
+              className="font-mono text-sm text-slate hover:text-teal transition-colors"
+            >
+              <span className="text-teal mr-1">0{i + 1}.</span>
+              {label}
+            </Tag>
+          );
+        })}
         <a
           href="https://tinyurl.com/46e8rzvb"
           target="_blank"

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'res.cloudinary.com' },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tailwindcss/typography": "^0.5.19",
     "better-auth": "^1.6.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,13 @@
     postcss "^8.5.6"
     tailwindcss "4.2.2"
 
+"@tailwindcss/typography@^0.5.19":
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.19.tgz#ecb734af2569681eb40932f09f60c2848b909456"
+  integrity sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==
+  dependencies:
+    postcss-selector-parser "6.0.10"
+
 "@ts-morph/common@~0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.27.0.tgz#e83a1bd7cbac054045c6246a7c4c99eab7692d46"
@@ -3981,6 +3988,14 @@ possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^7.1.0:
   version "7.1.1"


### PR DESCRIPTION
## Summary
- `GET /blog` — paginated grid of published posts (6/page via `?page=` param), empty state when no posts
- `GET /blog/:slug` — full post page with cover image, tags, TipTap HTML content, SEO metadata
- Blog link added to main header nav
- Cloudinary image domain added to `next.config.ts`
- `@tailwindcss/typography` installed for `prose` styles on post content

## Components
- `PostCard` — cover image, title, excerpt, date, tags
- `TagBadge` — shadcn Badge wrapper
- `Pagination` — prev/next with `?page=` search param